### PR TITLE
Add automated testing with Github Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,8 @@ jobs:
   test:
     strategy:
       matrix:
-        os: ["ubuntu-latest"]
-        python-version: ["3.8"]
+        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     defaults:
       run:
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: test
+
+on: [push]
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: ["ubuntu-latest"]
+        python-version: ["3.8"]
+    defaults:
+      run:
+        shell: bash
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+      - name: Install project
+        run: poetry install --no-interaction
+      - name: Run Pytest
+        run: poetry run pytest


### PR DESCRIPTION
This PR adds a Github Actions workflow that runs the test suite.

I limited it to only Ubuntu (Linux) and Python 3.8, though additional platforms (Windows and Mac) and Python versions can be added by appending to the corresponding `matrix` variables. I can amend this PR if testing on more platforms is desired.

The current test suite has failing tests on tests that use IPv6. This appears to be because the Github runner does not have a default IPv6 gateway.