### PR TITLE
Fix IPv6 tests failing when no default gateway is found

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: test
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,3 +27,24 @@ jobs:
         run: sudo ip -6 route add table local ff11::/16 dev lo
       - name: Run Pytest
         run: poetry run pytest
+
+  my-py:
+    strategy:
+      matrix:
+        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+    defaults:
+      run:
+        shell: bash
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.8"
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+      - name: Install project
+        run: poetry install --no-interaction
+      - name: Run Mypy
+        run: poetry run mypy multicast_expert

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,5 +22,8 @@ jobs:
         uses: snok/install-poetry@v1
       - name: Install project
         run: poetry install --no-interaction
+      - name: Configure IP routes # See "Development Setup.md"
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: sudo ip -6 route add table local ff11::/16 dev lo
       - name: Run Pytest
         run: poetry run pytest

--- a/multicast_expert/os_multicast.py
+++ b/multicast_expert/os_multicast.py
@@ -1,6 +1,6 @@
 # Script containing the nitty-gritty OS level functions of multicast_expert.
 
-import platform
+import sys
 import socket
 import struct
 import ctypes
@@ -11,7 +11,7 @@ from .utils import is_mac, is_windows
 import netifaces
 
 # Import needed Win32 DLL functions
-if is_windows:
+if sys.platform == 'win32':
     iphlpapi = ctypes.WinDLL('iphlpapi')
     win32_GetAdapterIndex = iphlpapi.GetAdapterIndex
     win32_GetAdapterIndex.argtypes = [ctypes.c_wchar_p, ctypes.POINTER(ctypes.c_ulong)]
@@ -44,7 +44,7 @@ def iface_name_to_index(iface_name: str) -> int:
     Convert a network interface's name into its interface index.
     """
 
-    if is_windows:
+    if sys.platform == 'win32':
 
         # To get the if index on Windows we have to use the GetAdapterIndex() function.
         # docs here: https://docs.microsoft.com/en-us/windows/win32/api/iphlpapi/nf-iphlpapi-getadapterindex

--- a/multicast_expert/tx_socket.py
+++ b/multicast_expert/tx_socket.py
@@ -64,7 +64,7 @@ class McastTxSocket:
         self.socket = socket.socket(family=self.addr_family, type=socket.SOCK_DGRAM)
 
         # Note: for Unix IPv6, need to specify the scope ID in the bind address
-        if self.addr_family == socket.AF_INET6:
+        if self.addr_family == socket.AF_INET6 and not is_windows:
             self.socket.bind((self.iface_ip, 0, 0, self.iface_info.iface_idx))
         else:
             self.socket.bind((self.iface_ip, 0)) # Bind to any available port

--- a/multicast_expert/tx_socket.py
+++ b/multicast_expert/tx_socket.py
@@ -62,7 +62,12 @@ class McastTxSocket:
 
         # Open the socket and set options
         self.socket = socket.socket(family=self.addr_family, type=socket.SOCK_DGRAM)
-        self.socket.bind((self.iface_ip, 0)) # Bind to any available port
+
+        # Note: for Unix IPv6, need to specify the scope ID in the bind address
+        if self.addr_family == socket.AF_INET6:
+            self.socket.bind((self.iface_ip, 0, 0, self.iface_info.iface_idx))
+        else:
+            self.socket.bind((self.iface_ip, 0)) # Bind to any available port
 
         # Use the IP_MULTICAST_IF option to set the interface to use.
         os_multicast.set_multicast_if(self.socket, self.mcast_ips, self.iface_info, self.addr_family)


### PR DESCRIPTION
The test suite is currently failing because the default IPv6 interface cannot be found. This PR will fallback on an arbitrarily chosen IPv6 interface if the default gateway is not found.