### PR TITLE
Add option to enable loop back on external interfaces

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "multicast_expert"
-version = "1.3.0"
+version = "1.4.0"
 description = "A library to take the fiddly parts out of multicast networking!"
 authors = ["Jamie Smith <jsmith@crackofdawn.onmicrosoft.com>"]
 license = "MIT"


### PR DESCRIPTION
By default `multicast_expert` will ignore self-reception of packets sent on external/non-loopback interfaces. This PR adds the ability to override the default behavior and receive multicast packets sent over external/non-loopback interfaces. 

This PR adds the `enable_external_loopback` parameter to both `McastRxSocket` and `McastTxSocket` initializers. When `enable_external_loopback` is `True`, `multicast_expert` will be able to receive multicast packets sent with an external, non-loopback interface.
