### PR TITLE
Use only one OS socket per McastRxSocket on Unix IPv4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,16 @@ Lorem Ipsum dolor sit amet.
 
 _______________________________________________________________________________
 
+## [1.5.1] - 2025-03-03
+
+### Changed
+
+- McastRxSockets for Unix IPv4 now use only one OS socket internally, and use IP_MULTICAST_ALL=0 to maintain isolation between other multicast groups. This should improve performance as there are no longer a potentially large number of sockets that need to be select()-ed when receiving.
+  - This has the side effect that Unix IPv4 McastRxSockets can now receive unicast packets going to the port number that the socket is opened on (on any interface). 
+- Transmitting via localhost on Windows to a port+group combo with no Rx socket open now simply does nothing (consistent with other platforms) instead of producing a WinError. 
+
+_______________________________________________________________________________
+
 ## [1.5.0] - 2025-02-07
 
 This release is focused on addressing the performance issues caused by multicast_expert rescanning the network interfaces on the machine each time a socket is opened. You can now avoid this overhead by using the new scan functions and then passing their result into the socket constructors' `iface` argument.

--- a/README.rst
+++ b/README.rst
@@ -79,8 +79,8 @@ Now let's get into some actual code examples.  Now first, before we can create a
 
 >>> import multicast_expert
 >>> multicast_expert.scan_interfaces()
-IfaceInfo(machine_name='{E61AD7AD-0125-4162-9967-98BE8A9CB330}', index=20, link_layer_address='ad:b7:80:13:19:12', ip4_addrs=[], ip6_addrs=[IPv6Address('fe80::1234:5678:%20/64')])
-IfaceInfo(machine_name='{195D3CB7-6D21-4C5A-8514-C4F01494FDC0}', index=37, link_layer_address='a6:b7:80:20:19:12', ip4_addrs=[IPv4Address('192.168.1.5/24')], ip6_addrs=[IPv6Address('fe80::1111:2222%37/64')])
+IfaceInfo(machine_name='{E61AD7AD-0125-4162-9967-98BE8A9CB330}', index=20, link_layer_address='ad:b7:80:13:19:12', ip4_addrs=[], ip6_addrs=[IPv6Interface('fe80::1234:5678:%20/64')])
+IfaceInfo(machine_name='{195D3CB7-6D21-4C5A-8514-C4F01494FDC0}', index=37, link_layer_address='a6:b7:80:20:19:12', ip4_addrs=[IPv4Interface('192.168.1.5/24')], ip6_addrs=[IPv6Interface('fe80::1111:2222%37/64')])
 
 (note that this function is a wrapper around the netifaces library, which provides quite a bit more functionality if you need it)
 
@@ -185,6 +185,3 @@ Q: What if, rather than using a Multicast Expert socket inside a single ``with``
             self.exit_stack = None
 
 With this setup, the socket will be opened when you call ``init()``, and will stay open until someone calls ``deinit()``.  Note however that this transfers the responsibility for closing the socket onto you: if you forget to call ``deinit()`` before you're done using the class, the socket could stay open longer than intended.
-
-Q: When I try to send a packet to the loopback address on Windows, I get "[WinError 10051] A socket operation was attempted to an unreachable network"!
-    A: On Windows, to send multicasts through the loopback interface, you must open a listening socket before trying to send packets, or an error will be generated. So, make sure there's an application listing to the loopback interface on the correct port before you send your multicast packet.

--- a/README.rst
+++ b/README.rst
@@ -125,8 +125,8 @@ FAQ
 Q: What happens if an interface changes IP address (e.g. due to the user modifying a static IP) after I create a multicast socket on that interface?
     A: On all machines tested so far, multicast sockets will stick with their assigned interface once created, even if the IP of that interface changes or it is brought down.
 
-Q: Do McastRxSockets receive regular (unicast) UDP packets going to the same interface and port?
-    A: On Windows, yes.  On Unix, no.  Unfortunately, this is a platform difference that I haven't found an easy way to work around.
+Q: Do McastRxSockets receive regular (unicast) UDP packets going to the same port number?
+    A: In most cases yes, though this is not behavior that should be depended on. For example, on Windows IPv4, only unicast packets arriving at the specific interfaces on which the socket is open will be received, whereas on Unix IPv4, *all* unicast packets arriving on any interface with the right port number will be received.
 
 Q: Can I create multiple McastRxSockets on the same port and interface?
     A: As long as they have different mcast addresses, then yes, this works how you'd expect.

--- a/multicast_expert/rx_socket.py
+++ b/multicast_expert/rx_socket.py
@@ -194,7 +194,6 @@ class McastRxSocket:
                         new_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 
                         # Note: for Unix IPv6, need to specify the scope ID in the bind address in order for link-local mcast addresses to work.
-                        # Also, for IPv6, len(ifaces_this_socket) is always 1.
                         new_socket.bind((str(mcast_ip), self.port, 0, iface_info.index))
 
                         os_multicast.add_memberships(new_socket, [mcast_ip], iface_info, self.addr_family)

--- a/multicast_expert/rx_socket.py
+++ b/multicast_expert/rx_socket.py
@@ -216,7 +216,8 @@ class McastRxSocket:
                     # receiving packets to the same interface + port but a different multicast address.
                     # Sadly the IP_MULTICAST_ALL constant is not available in python yet
                     # (no bug open, but mentioned here)
-                    IP_MULTICAST_ALL = 49
+                    # https://github.com/python/cpython/pull/10294#issuecomment-1374345142
+                    IP_MULTICAST_ALL = 49  # noqa: N806
                     all_group_socket.setsockopt(socket.IPPROTO_IP, IP_MULTICAST_ALL, 0)
 
                 all_group_socket.bind(("0.0.0.0", self.port))

--- a/multicast_expert/rx_socket.py
+++ b/multicast_expert/rx_socket.py
@@ -186,7 +186,6 @@ class McastRxSocket:
 
                 self.sockets.append(new_socket)
         else:
-
             if self.addr_family == socket.AF_INET6:
                 # For IPv6 on Unix, we need to create one socket for each mcast_ip - iface permutation.
                 for mcast_ip in self.mcast_ips:
@@ -196,26 +195,26 @@ class McastRxSocket:
 
                         # Note: for Unix IPv6, need to specify the scope ID in the bind address in order for link-local mcast addresses to work.
                         # Also, for IPv6, len(ifaces_this_socket) is always 1.
-                        new_socket.bind((str(mcast_ip), self.port, 0, new_socket.index))
+                        new_socket.bind((str(mcast_ip), self.port, 0, iface_info.index))
 
                         os_multicast.add_memberships(new_socket, [mcast_ip], iface_info, self.addr_family)
 
                         self.sockets.append(new_socket)
-                else:
-                    # Unix IPv4 -- just open one socket and bind it to the needed interfaces and groups.
-                    all_group_socket = socket.socket(family=self.addr_family, type=socket.SOCK_DGRAM)
-                    all_group_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-                    all_group_socket.bind(("0.0.0.0", self.port))
+            else:
+                # Unix IPv4 -- just open one socket and bind it to the needed interfaces and groups.
+                all_group_socket = socket.socket(family=self.addr_family, type=socket.SOCK_DGRAM)
+                all_group_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                all_group_socket.bind(("0.0.0.0", self.port))
 
-                    for iface_info in self._iface_infos:
-                        if self.is_source_specific:
-                            os_multicast.add_source_specific_memberships(
-                                all_group_socket, self.mcast_ips, self.source_ips, iface_info
-                            )
-                        else:
-                            os_multicast.add_memberships(all_group_socket, self.mcast_ips, iface_info, self.addr_family)
+                for iface_info in self._iface_infos:
+                    if self.is_source_specific:
+                        os_multicast.add_source_specific_memberships(
+                            all_group_socket, self.mcast_ips, self.source_ips, iface_info
+                        )
+                    else:
+                        os_multicast.add_memberships(all_group_socket, self.mcast_ips, iface_info, self.addr_family)
 
-                    self.sockets.append(all_group_socket)
+                self.sockets.append(all_group_socket)
 
         self.is_opened = True
 

--- a/multicast_expert/tx_socket.py
+++ b/multicast_expert/tx_socket.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ipaddress
 import socket
+import sys
 from collections.abc import Sequence
 from types import TracebackType
 from typing import TYPE_CHECKING
@@ -174,11 +175,11 @@ class McastTxSocket:
         try:
             self.socket.sendto(tx_bytes, address)
         except OSError as ex:
-            # Windows will fail a sendto() call on the loopback address if it knows that no Rx socket is available
-            # to receive the packet. That's kinda nice but it's incompatible with the behavior of every other platform,
-            # and it also doesn't do it consistently.
-            # So, we just swallow the exception in this case.
-            if hasattr(ex, "winerr"):
+            if sys.platform == "win32":
+                # Windows will fail a sendto() call on the loopback address if it knows that no Rx socket is available
+                # to receive the packet. That's kinda nice but it's incompatible with the behavior of every other platform,
+                # and it also doesn't do it consistently.
+                # So, we just swallow the exception in this case.
                 if ex.winerror == 10051:
                     return
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ name = "multicast_expert"
 # "~=3.9", so Poetry won't solve the versions since it cannot find a version of docsig that works for Python >=4
 requires-python = "~=3.9"
 
-version = "1.5.0"
+version = "1.6.0"
 description = "A library to take the fiddly parts out of multicast networking!"
 authors = [
     {name = "Jamie Smith", email = "jsmith@crackofdawn.onmicrosoft.com"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,8 @@ ignore = [
     'PERF203', # Allow try-except within loops. Sometimes this is needed!
     'ERA001',  # Allow commented code. This lint gets a false positive on docsig ignore comments!
     'PERF401', # Allow for loops that could be comprehensions. Sometimes this makes code easier to understand.
+    'S104',    # Allow binding sockets to the wildcard interface. In our case, we apply socket options to those sockets so that they are restricted to specific interfaces and mcast IPs
+    'PLR5501', # Stop collapsing my if statements!
 ]
 
 [tool.ruff.lint.flake8-quotes]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ name = "multicast_expert"
 # "~=3.9", so Poetry won't solve the versions since it cannot find a version of docsig that works for Python >=4
 requires-python = "~=3.9"
 
-version = "1.6.0"
+version = "1.5.1"
 description = "A library to take the fiddly parts out of multicast networking!"
 authors = [
     {name = "Jamie Smith", email = "jsmith@crackofdawn.onmicrosoft.com"}

--- a/tests/test_multicast_sockets.py
+++ b/tests/test_multicast_sockets.py
@@ -337,6 +337,7 @@ def test_v4_different_mcast_addr_blocked() -> None:
             mcast_ips=[mcast_address_v4_alternate],
             port=port,
             iface_ip=multicast_expert.get_default_gateway_iface_ip_v4(),
+            timeout=0.25,
         ) as alternate_rx_sock,
         multicast_expert.McastTxSocket(
             socket.AF_INET, mcast_ips=[mcast_address_v4_alternate], iface_ip=multicast_expert.LOCALHOST_IPV4

--- a/tests/test_multicast_sockets.py
+++ b/tests/test_multicast_sockets.py
@@ -347,13 +347,7 @@ def test_v4_different_mcast_addr_blocked() -> None:
 
         # Neither socket should receive anything: mcast_rx_sock is on the right interface but the wrong mcast address,
         # and alternate_rx_sock is on the right mcast address but the wrong interface
-        try:
-            assert mcast_rx_sock.recvfrom() is None
-        except OSError as ex:
-            # WindowsError 10051 also OK because we are trying to receive from a socket on localhost, and windows
-            # can insta-error in this case.
-            assert hasattr(ex, "winerr") and ex.winerror == 10051
-
+        assert mcast_rx_sock.recvfrom() is None
         assert alternate_rx_sock.recvfrom() is None
 
 

--- a/tests/test_multicast_sockets.py
+++ b/tests/test_multicast_sockets.py
@@ -347,7 +347,13 @@ def test_v4_different_mcast_addr_blocked() -> None:
 
         # Neither socket should receive anything: mcast_rx_sock is on the right interface but the wrong mcast address,
         # and alternate_rx_sock is on the right mcast address but the wrong interface
-        assert mcast_rx_sock.recvfrom() is None
+        try:
+            assert mcast_rx_sock.recvfrom() is None
+        except OSError as ex:
+            # WindowsError 10051 also OK because we are trying to receive from a socket on localhost, and windows
+            # can insta-error in this case.
+            assert hasattr(ex, "winerr") and ex.winerror == 10051
+
         assert alternate_rx_sock.recvfrom() is None
 
 

--- a/tests/test_multicast_sockets.py
+++ b/tests/test_multicast_sockets.py
@@ -287,22 +287,6 @@ def test_blocking_false() -> None:
 
 
 @pytest.mark.skipif(platform.system() == "Windows", reason="Does not pass on Windows")
-def test_v4_unicast_blocked() -> None:
-    """
-    Check that unicast packets cannot be received by a multicast socket
-    """
-    with multicast_expert.McastRxSocket(
-        socket.AF_INET, mcast_ips=[mcast_address_v4], port=port, iface_ip=multicast_expert.LOCALHOST_IPV4, timeout=0.25
-    ) as mcast_rx_sock:
-        tx_socket = socket.socket(family=socket.AF_INET, type=socket.SOCK_DGRAM)
-        tx_socket.sendto(b"Ignore this plz", (multicast_expert.LOCALHOST_IPV4, port))
-
-        assert mcast_rx_sock.recvfrom() is None
-
-        tx_socket.close()
-
-
-@pytest.mark.skipif(platform.system() == "Windows", reason="Does not pass on Windows")
 def test_v6_unicast_blocked() -> None:
     """
     Check that unicast packets cannot be received by a multicast socket


### PR DESCRIPTION
Until now, I had thought it was impossible, on Unix OSs, to subscribe to multiple multicast groups on one socket. And while I still suspect that this is the case for IPv6, thanks to my colleagues Jasper and Pavel, we have discovered that this is not true for IPv4. By setting the IP_MULTICAST_ALL option to false, the socket will only receive from the exact multicast addresses it's subscribed to, rather than all multicasts arriving to that interface + port combo.

I added a new test to confirm this behavior, and verified that the tests (specifically test_v4_loopback_multiple) failed on Linux until I added the IP_MULTICAST_ALL option.

I also updated the README and changelog to reflect the changes.
