### PR TITLE
Implement AsyncMcastRxSocket, providing asynchronous I/O support

### DIFF
--- a/.github/workflows/linting_and_formatting.yml
+++ b/.github/workflows/linting_and_formatting.yml
@@ -17,10 +17,10 @@ jobs:
       run: |
         npm install -g pyright
 
-    - name: Set up Python 3.10
+    - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.11'
 
     - name: Install Poetry
       uses: Gr1N/setup-poetry@v9

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,9 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          # Normally we want to run this using the oldest supported python version to catch errors,
+          # but we need at least py3.11 for the async code to work.
+          python-version: "3.11"
       - name: Install Poetry
         uses: Gr1N/setup-poetry@v9
       - name: Install project

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,14 @@ Lorem Ipsum dolor sit amet.
 
 _______________________________________________________________________________
 
+## [1.6.0] - 2025-03-04
+
+### Added
+
+- `AsyncMcastRxSocket` is now available (as long as you are using Python 3.11 or later). This class provides an asyncio-compatible way to receive with a multicast Rx socket.
+
+_______________________________________________________________________________
+
 ## [1.5.1] - 2025-03-03
 
 ### Changed

--- a/README.rst
+++ b/README.rst
@@ -116,6 +116,12 @@ The above code will listen on the 239.1.2.3 multicast address, and will block un
 
 For receiving multicasts, you often don't need to pass an interface name, as the default is to listen on all possible interfaces of the machine. However, you can pass one or more specific interfaces to listen on if you like, for performance or functionality reasons.
 
+Also, as of multicast_expert 1.6.0, as long as you have Python >=3.11, there is an asynchronous version of the Rx socket available:
+>>> with multicast_expert.AsyncMcastRxSocket(socket.AF_INET, mcast_ips=['239.1.2.3'], port=12345) as mcast_rx_sock:
+...     bytes, src_address = await mcast_rx_sock.recvfrom()
+
+This version of the code can be used inside an async context to give up control until the socket has received one or more packets. The timeout (as set via settimeout() or the constructor) is obeyed by the async version of the socket as well.
+
 Full Example
 ============
 For a complete example of how to use this library, see the system test script `here <https://github.com/multiplemonomials/multicast_expert/blob/main/examples/mcast_communicator.py>`_.

--- a/multicast_expert/__init__.py
+++ b/multicast_expert/__init__.py
@@ -38,10 +38,12 @@ from multicast_expert.interfaces import get_default_gateway_iface_ip_v4 as get_d
 from multicast_expert.interfaces import get_default_gateway_iface_ip_v6 as get_default_gateway_iface_ip_v6
 from multicast_expert.interfaces import get_interface_ips as get_interface_ips
 from multicast_expert.interfaces import scan_interfaces as scan_interfaces
-from multicast_expert.rx_socket import AsyncMcastRxSocket as AsyncMcastRxSocket
 from multicast_expert.rx_socket import McastRxSocket as McastRxSocket
 from multicast_expert.tx_socket import McastTxSocket as McastTxSocket
 from multicast_expert.utils import IPv4Or6Address as IPv4Or6Address
 from multicast_expert.utils import MulticastAddress as MulticastAddress
 from multicast_expert.utils import MulticastExpertError as MulticastExpertError
 from multicast_expert.utils import validate_mcast_ip as validate_mcast_ip
+
+if sys.version_info >= (3, 11):
+    from multicast_expert.async_rx_socket import AsyncMcastRxSocket as AsyncMcastRxSocket

--- a/multicast_expert/__init__.py
+++ b/multicast_expert/__init__.py
@@ -38,6 +38,7 @@ from multicast_expert.interfaces import get_default_gateway_iface_ip_v4 as get_d
 from multicast_expert.interfaces import get_default_gateway_iface_ip_v6 as get_default_gateway_iface_ip_v6
 from multicast_expert.interfaces import get_interface_ips as get_interface_ips
 from multicast_expert.interfaces import scan_interfaces as scan_interfaces
+from multicast_expert.rx_socket import AsyncMcastRxSocket as AsyncMcastRxSocket
 from multicast_expert.rx_socket import McastRxSocket as McastRxSocket
 from multicast_expert.tx_socket import McastTxSocket as McastTxSocket
 from multicast_expert.utils import IPv4Or6Address as IPv4Or6Address

--- a/multicast_expert/async_rx_socket.py
+++ b/multicast_expert/async_rx_socket.py
@@ -40,7 +40,7 @@ class AsyncMcastRxSocket(BaseMcastRxSocket):
         # Start a receive operation on each of the sockets.
         # We do this now so that we can have a known future for each socket that is active at all times.
         self._recvfrom_tasks: dict[socket.socket, asyncio.Task[tuple[socket.socket, PacketAndSenderAddress]]] = {
-            sock: asyncio.get_running_loop().create_task(self._recvfrom_wrapper(sock)) for sock in self.sockets
+            sock: asyncio.create_task(self._recvfrom_wrapper(sock)) for sock in self.sockets
         }
 
         return self
@@ -83,7 +83,7 @@ class AsyncMcastRxSocket(BaseMcastRxSocket):
         sock, result_packet = await next(iter(done))
 
         # Reschedule another receive for this socket
-        self._recvfrom_tasks[sock] = asyncio.get_running_loop().create_task(self._recvfrom_wrapper(sock))
+        self._recvfrom_tasks[sock] = asyncio.create_task(self._recvfrom_wrapper(sock))
 
         return result_packet
 

--- a/multicast_expert/async_rx_socket.py
+++ b/multicast_expert/async_rx_socket.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from typing_extensions import Self
 
-from multicast_expert.rx_socket import DEFAULT_RX_BUFSIZE, BaseMcastRxSocket, PacketAndAddress
+from multicast_expert.rx_socket import DEFAULT_RX_BUFSIZE, BaseMcastRxSocket, PacketAndSenderAddress
 
 
 class AsyncMcastRxSocket(BaseMcastRxSocket):
@@ -17,26 +17,29 @@ class AsyncMcastRxSocket(BaseMcastRxSocket):
     """
 
     @staticmethod
-    async def _recvfrom_wrapper(sock: socket.socket) -> tuple[socket.socket, PacketAndAddress]:
+    async def _recvfrom_wrapper(sock: socket.socket) -> tuple[socket.socket, PacketAndSenderAddress]:
         """
         Wrapper around the EventLoop.sock_recvfrom() function.
 
         This is used to associate the packet data with the socket that received it. This seems to be needed
         as I wasn't able to find a way to attach "metadata" to a future in a way that passes through ``asyncio.wait()``.
         """
-        packet_and_addr: PacketAndAddress = await asyncio.get_running_loop().sock_recvfrom(sock, DEFAULT_RX_BUFSIZE)
+        packet_and_addr: PacketAndSenderAddress = await asyncio.get_running_loop().sock_recvfrom(
+            sock, DEFAULT_RX_BUFSIZE
+        )
         return sock, packet_and_addr
 
     def __enter__(self) -> Self:
         super().__enter__()
 
         # For asyncio socket functions, we need to set the timeout on the actual sockets to 0 (nonblocking).
+        # Then we pass self.timeout to asyncio.wait() later.
         for sock in self.sockets:
             sock.settimeout(0)
 
         # Start a receive operation on each of the sockets.
         # We do this now so that we can have a known future for each socket that is active at all times.
-        self._recvfrom_tasks: dict[socket.socket, asyncio.Task[tuple[socket.socket, PacketAndAddress]]] = {
+        self._recvfrom_tasks: dict[socket.socket, asyncio.Task[tuple[socket.socket, PacketAndSenderAddress]]] = {
             sock: asyncio.get_running_loop().create_task(self._recvfrom_wrapper(sock)) for sock in self.sockets
         }
 
@@ -51,7 +54,7 @@ class AsyncMcastRxSocket(BaseMcastRxSocket):
 
         super().__exit__(exc_type, exc, traceback)
 
-    async def recvfrom(self) -> PacketAndAddress:
+    async def recvfrom(self) -> PacketAndSenderAddress:
         """
         Asynchronously receive a UDP packet from the socket.
 
@@ -60,7 +63,8 @@ class AsyncMcastRxSocket(BaseMcastRxSocket):
 
         This respects the current blocking and timeout settings.
 
-        :return: List of tuples of (bytes, address).  For IPv4, address is a tuple of IP address (str) and port number.
+        :return: List of tuples of (bytes, address).  For IPv4, address is a tuple of sender IP address (str) and
+            port number.
             For IPv6, address is a tuple of IP address (str), port number, flow info (int), and scope ID (int).
         :raises asyncio.TimeoutError: If no packets were received within the timeout. If the timeout is 0, this is
             raised if there were no packets available to be returned immediately.

--- a/multicast_expert/async_rx_socket.py
+++ b/multicast_expert/async_rx_socket.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import asyncio
+import socket
+from types import TracebackType
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
+
+from multicast_expert.rx_socket import DEFAULT_RX_BUFSIZE, BaseMcastRxSocket, PacketAndAddress
+
+
+class AsyncMcastRxSocket(BaseMcastRxSocket):
+    """
+    Class to wrap a socket that receives from one or more multicast groups using asynchronous operations.
+    """
+
+    @staticmethod
+    async def _recvfrom_wrapper(sock: socket.socket) -> tuple[socket.socket, PacketAndAddress]:
+        """
+        Wrapper around the EventLoop.sock_recvfrom() function.
+
+        This is used to associate the packet data with the socket that received it. This seems to be needed
+        as I wasn't able to find a way to attach "metadata" to a future in a way that passes through ``asyncio.wait()``.
+        """
+        packet_and_addr: PacketAndAddress = await asyncio.get_running_loop().sock_recvfrom(sock, DEFAULT_RX_BUFSIZE)
+        return sock, packet_and_addr
+
+    def __enter__(self) -> Self:
+        super().__enter__()
+
+        # For asyncio socket functions, we need to set the timeout on the actual sockets to 0 (nonblocking).
+        for sock in self.sockets:
+            sock.settimeout(0)
+
+        # Start a receive operation on each of the sockets.
+        # We do this now so that we can have a known future for each socket that is active at all times.
+        self._recvfrom_tasks: dict[socket.socket, asyncio.Task[tuple[socket.socket, PacketAndAddress]]] = {
+            sock: asyncio.get_running_loop().create_task(self._recvfrom_wrapper(sock)) for sock in self.sockets
+        }
+
+        return self
+
+    def __exit__(
+        self, exc_type: type[BaseException] | None, exc: BaseException | None, traceback: TracebackType | None
+    ) -> None:
+        # Cancel all tasks
+        for recvfrom_task in self._recvfrom_tasks.values():
+            recvfrom_task.cancel()
+
+        super().__exit__(exc_type, exc, traceback)
+
+    async def recvfrom(self) -> PacketAndAddress:
+        """
+        Asynchronously receive a UDP packet from the socket.
+
+        Note that multicast_expert uses multiple sockets under the hood in some cases, and if multiple sockets
+        are in use, this will dequeue and return a packet from one of those sockets (which socket is not defined).
+
+        This respects the current blocking and timeout settings.
+
+        :return: List of tuples of (bytes, address).  For IPv4, address is a tuple of IP address (str) and port number.
+            For IPv6, address is a tuple of IP address (str), port number, flow info (int), and scope ID (int).
+        :raises asyncio.TimeoutError: If no packets were received within the timeout. If the timeout is 0, this is
+            raised if there were no packets available to be returned immediately.
+        """
+        # Do a "select" from all the current recvfrom futures to find one that is done.
+        done, pending = await asyncio.wait(
+            self._recvfrom_tasks.values(), timeout=self.timeout, return_when=asyncio.FIRST_COMPLETED
+        )
+
+        if len(done) == 0:
+            # No sockets can be read
+            raise asyncio.TimeoutError
+
+        # Pick some arbitrary one from the done list and get its result. Others in the done list will be gotten on
+        # the next call to this function.
+        sock, result_packet = await next(iter(done))
+
+        # Reschedule another receive for this socket
+        self._recvfrom_tasks[sock] = asyncio.get_running_loop().create_task(self._recvfrom_wrapper(sock))
+
+        return result_packet
+
+    async def recv(self) -> bytes:
+        """
+        Asynchronously receive a UDP packet from the socket, returning the bytes.
+
+        Note that multicast_expert uses multiple sockets under the hood in some cases, and if multiple sockets
+        are in use, this will dequeue and return a packet from one of those sockets (which socket is not defined).
+
+        This respects the current blocking and timeout settings.
+
+        :return: Bytes received.
+        :raises asyncio.TimeoutError: If no packets were received within the timeout. If the timeout is 0, this is
+            raised if there were no packets available to be returned immediately.
+        """
+        packet_and_addr = await self.recvfrom()
+        return packet_and_addr[0]

--- a/multicast_expert/rx_socket.py
+++ b/multicast_expert/rx_socket.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import ipaddress
 import select
 import socket
@@ -334,92 +333,3 @@ class McastRxSocket(BaseMcastRxSocket):
             return None
         else:
             return packet_and_addr[0]
-
-
-class AsyncMcastRxSocket(BaseMcastRxSocket):
-    """
-    Class to wrap a socket that receives from one or more multicast groups using asynchronous operations.
-    """
-
-    @staticmethod
-    async def _recvfrom_wrapper(sock: socket.socket) -> tuple[socket.socket, PacketAndAddress]:
-        """
-        Wrapper around the EventLoop.sock_recvfrom() function.
-
-        This is used to associate the packet data with the socket that received it. This seems to be needed
-        as I wasn't able to find a way to attach "metadata" to a future in a way that passes through ``asyncio.wait()``.
-        """
-        packet_and_addr: PacketAndAddress = await asyncio.get_running_loop().sock_recvfrom(sock, DEFAULT_RX_BUFSIZE)
-        return sock, packet_and_addr
-
-    def __enter__(self) -> Self:
-        super().__enter__()
-
-        # For asyncio socket functions, we need to set the timeout on the actual sockets to 0 (nonblocking).
-        for sock in self.sockets:
-            sock.settimeout(0)
-
-        # Start a receive operation on each of the sockets.
-        # We do this now so that we can have a known future for each socket that is active at all times.
-        self._recvfrom_tasks: dict[socket.socket, asyncio.Task[tuple[socket.socket, PacketAndAddress]]] = {
-            sock: asyncio.get_running_loop().create_task(self._recvfrom_wrapper(sock)) for sock in self.sockets
-        }
-
-        return self
-
-    def __exit__(
-        self, exc_type: type[BaseException] | None, exc: BaseException | None, traceback: TracebackType | None
-    ) -> None:
-        # Cancel all tasks
-        for recvfrom_task in self._recvfrom_tasks.values():
-            recvfrom_task.cancel()
-
-        super().__exit__(exc_type, exc, traceback)
-
-    async def recvfrom(self) -> PacketAndAddress:
-        """
-        Asynchronously receive a UDP packet from the socket.
-
-        Note that multicast_expert uses multiple sockets under the hood in some cases, and if multiple sockets
-        are in use, this will dequeue and return a packet from one of those sockets (which socket is not defined).
-
-        This respects the current blocking and timeout settings.
-
-        :return: List of tuples of (bytes, address).  For IPv4, address is a tuple of IP address (str) and port number.
-            For IPv6, address is a tuple of IP address (str), port number, flow info (int), and scope ID (int).
-        :raises asyncio.TimeoutError: If no packets were received within the timeout. If the timeout is 0, this is
-            raised if there were no packets available to be returned immediately.
-        """
-        # Do a "select" from all the current recvfrom futures to find one that is done.
-        done, pending = await asyncio.wait(
-            self._recvfrom_tasks.values(), timeout=self.timeout, return_when=asyncio.FIRST_COMPLETED
-        )
-
-        if len(done) == 0:
-            # No sockets can be read
-            raise asyncio.TimeoutError
-
-        # Pick the first one from the done list and return it. Others in the done list will be gotten on
-        # the next call to this function.
-        sock, result_packet = await next(iter(done))
-
-        # Reschedule another receive for this socket
-        self._recvfrom_tasks[sock] = asyncio.get_running_loop().create_task(self._recvfrom_wrapper(sock))
-
-        return result_packet
-
-    async def recv(self) -> bytes:
-        """
-        Asynchronously receive a UDP packet from the socket, returning the bytes.
-
-        Note that multicast_expert uses multiple sockets under the hood in some cases, and if multiple sockets
-        are in use, this will dequeue and return a packet from one of those sockets (which socket is not defined).
-
-        This respects the current blocking and timeout settings.
-
-        :return: Bytes received.
-        :raises asyncio.TimeoutError: If no packets were received within the timeout. If the timeout is 0, this is
-            raised if there were no packets available to be returned immediately.
-        """
-        packet_and_addr = await self.recvfrom()
-        return packet_and_addr[0]

--- a/multicast_expert/rx_socket.py
+++ b/multicast_expert/rx_socket.py
@@ -22,7 +22,7 @@ from multicast_expert.utils import (
     validate_mcast_ip,
 )
 
-PacketAndAddress = tuple[bytes, IPv4Or6Address]
+PacketAndSenderAddress = tuple[bytes, IPv4Or6Address]
 DEFAULT_RX_BUFSIZE = 4096  # Used by socket module
 
 
@@ -286,7 +286,7 @@ class McastRxSocket(BaseMcastRxSocket):
     Class to wrap a socket that receives from one or more multicast groups.
     """
 
-    def recvfrom(self, bufsize: int = 4096, flags: int = 0) -> PacketAndAddress | None:
+    def recvfrom(self, bufsize: int = 4096, flags: int = 0) -> PacketAndSenderAddress | None:
         """
         Receive a UDP packet from the socket, returning the bytes and the sender address.
 
@@ -298,7 +298,7 @@ class McastRxSocket(BaseMcastRxSocket):
         :param bufsize: Maximum amount of data to be received at once.
         :param flags: Flags that will be passed to the OS.
 
-        :return: Tuple of (bytes, address).  For IPv4, address is a tuple of IP address (str) and port number.
+        :return: Tuple of (bytes, address).  For IPv4, address is a tuple of sender IP address (str) and port number.
             For IPv6, address is a tuple of IP address (str), port number, flow info (int), and scope ID (int).
             If no packets were received (nonblocking mode or timeout), None is returned.
         """

--- a/poetry.lock
+++ b/poetry.lock
@@ -183,14 +183,14 @@ files = [
 
 [[package]]
 name = "docsig"
-version = "0.68.0"
+version = "0.69.1"
 description = "Check signature params for proper documentation"
 optional = false
 python-versions = "<4.0.0,>=3.8.1"
 groups = ["dev"]
 files = [
-    {file = "docsig-0.68.0-py3-none-any.whl", hash = "sha256:8f6a2038d83c6afd96c36fb7f222024cdbe67686698b41f8efd5ab848ae98837"},
-    {file = "docsig-0.68.0.tar.gz", hash = "sha256:2ace2276adac132ca06956a35fe468eda21670e50f12c71ead778066d3837c8c"},
+    {file = "docsig-0.69.1-py3-none-any.whl", hash = "sha256:87ab6704351c5733ca5e1580c789112530f774bdfa8b38210b499568bc758687"},
+    {file = "docsig-0.69.1.tar.gz", hash = "sha256:a978548553ae1ffd3d91801b30e1317d2fb7bce6b185a7835da52be1e4acf59d"},
 ]
 
 [package.dependencies]
@@ -544,14 +544,14 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.3.4"
+version = "8.3.5"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6"},
-    {file = "pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761"},
+    {file = "pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820"},
+    {file = "pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845"},
 ]
 
 [package.dependencies]
@@ -564,6 +564,25 @@ tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 
 [package.extras]
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+
+[[package]]
+name = "pytest-asyncio"
+version = "0.25.3"
+description = "Pytest support for asyncio"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pytest_asyncio-0.25.3-py3-none-any.whl", hash = "sha256:9e89518e0f9bd08928f97a3482fdc4e244df17529460bc038291ccaf8f85c7c3"},
+    {file = "pytest_asyncio-0.25.3.tar.gz", hash = "sha256:fc1da2cf9f125ada7e710b4ddad05518d4cee187ae9412e9ac9271003497f07a"},
+]
+
+[package.dependencies]
+pytest = ">=8.2,<9"
+
+[package.extras]
+docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1)"]
+testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)"]
 
 [[package]]
 name = "pytest-mock"
@@ -625,30 +644,30 @@ use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "ruff"
-version = "0.9.4"
+version = "0.9.9"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
 files = [
-    {file = "ruff-0.9.4-py3-none-linux_armv6l.whl", hash = "sha256:64e73d25b954f71ff100bb70f39f1ee09e880728efb4250c632ceed4e4cdf706"},
-    {file = "ruff-0.9.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6ce6743ed64d9afab4fafeaea70d3631b4d4b28b592db21a5c2d1f0ef52934bf"},
-    {file = "ruff-0.9.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:54499fb08408e32b57360f6f9de7157a5fec24ad79cb3f42ef2c3f3f728dfe2b"},
-    {file = "ruff-0.9.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:37c892540108314a6f01f105040b5106aeb829fa5fb0561d2dcaf71485021137"},
-    {file = "ruff-0.9.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:de9edf2ce4b9ddf43fd93e20ef635a900e25f622f87ed6e3047a664d0e8f810e"},
-    {file = "ruff-0.9.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:87c90c32357c74f11deb7fbb065126d91771b207bf9bfaaee01277ca59b574ec"},
-    {file = "ruff-0.9.4-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:56acd6c694da3695a7461cc55775f3a409c3815ac467279dfa126061d84b314b"},
-    {file = "ruff-0.9.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e0c93e7d47ed951b9394cf352d6695b31498e68fd5782d6cbc282425655f687a"},
-    {file = "ruff-0.9.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1d4c8772670aecf037d1bf7a07c39106574d143b26cfe5ed1787d2f31e800214"},
-    {file = "ruff-0.9.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bfc5f1d7afeda8d5d37660eeca6d389b142d7f2b5a1ab659d9214ebd0e025231"},
-    {file = "ruff-0.9.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:faa935fc00ae854d8b638c16a5f1ce881bc3f67446957dd6f2af440a5fc8526b"},
-    {file = "ruff-0.9.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a6c634fc6f5a0ceae1ab3e13c58183978185d131a29c425e4eaa9f40afe1e6d6"},
-    {file = "ruff-0.9.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:433dedf6ddfdec7f1ac7575ec1eb9844fa60c4c8c2f8887a070672b8d353d34c"},
-    {file = "ruff-0.9.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:d612dbd0f3a919a8cc1d12037168bfa536862066808960e0cc901404b77968f0"},
-    {file = "ruff-0.9.4-py3-none-win32.whl", hash = "sha256:db1192ddda2200671f9ef61d9597fcef89d934f5d1705e571a93a67fb13a4402"},
-    {file = "ruff-0.9.4-py3-none-win_amd64.whl", hash = "sha256:05bebf4cdbe3ef75430d26c375773978950bbf4ee3c95ccb5448940dc092408e"},
-    {file = "ruff-0.9.4-py3-none-win_arm64.whl", hash = "sha256:585792f1e81509e38ac5123492f8875fbc36f3ede8185af0a26df348e5154f41"},
-    {file = "ruff-0.9.4.tar.gz", hash = "sha256:6907ee3529244bb0ed066683e075f09285b38dd5b4039370df6ff06041ca19e7"},
+    {file = "ruff-0.9.9-py3-none-linux_armv6l.whl", hash = "sha256:628abb5ea10345e53dff55b167595a159d3e174d6720bf19761f5e467e68d367"},
+    {file = "ruff-0.9.9-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b6cd1428e834b35d7493354723543b28cc11dc14d1ce19b685f6e68e07c05ec7"},
+    {file = "ruff-0.9.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5ee162652869120ad260670706f3cd36cd3f32b0c651f02b6da142652c54941d"},
+    {file = "ruff-0.9.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3aa0f6b75082c9be1ec5a1db78c6d4b02e2375c3068438241dc19c7c306cc61a"},
+    {file = "ruff-0.9.9-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:584cc66e89fb5f80f84b05133dd677a17cdd86901d6479712c96597a3f28e7fe"},
+    {file = "ruff-0.9.9-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:abf3369325761a35aba75cd5c55ba1b5eb17d772f12ab168fbfac54be85cf18c"},
+    {file = "ruff-0.9.9-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:3403a53a32a90ce929aa2f758542aca9234befa133e29f4933dcef28a24317be"},
+    {file = "ruff-0.9.9-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:18454e7fa4e4d72cffe28a37cf6a73cb2594f81ec9f4eca31a0aaa9ccdfb1590"},
+    {file = "ruff-0.9.9-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0fadfe2c88724c9617339f62319ed40dcdadadf2888d5afb88bf3adee7b35bfb"},
+    {file = "ruff-0.9.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6df104d08c442a1aabcfd254279b8cc1e2cbf41a605aa3e26610ba1ec4acf0b0"},
+    {file = "ruff-0.9.9-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d7c62939daf5b2a15af48abbd23bea1efdd38c312d6e7c4cedf5a24e03207e17"},
+    {file = "ruff-0.9.9-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:9494ba82a37a4b81b6a798076e4a3251c13243fc37967e998efe4cce58c8a8d1"},
+    {file = "ruff-0.9.9-py3-none-musllinux_1_2_i686.whl", hash = "sha256:4efd7a96ed6d36ef011ae798bf794c5501a514be369296c672dab7921087fa57"},
+    {file = "ruff-0.9.9-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:ab90a7944c5a1296f3ecb08d1cbf8c2da34c7e68114b1271a431a3ad30cb660e"},
+    {file = "ruff-0.9.9-py3-none-win32.whl", hash = "sha256:6b4c376d929c25ecd6d87e182a230fa4377b8e5125a4ff52d506ee8c087153c1"},
+    {file = "ruff-0.9.9-py3-none-win_amd64.whl", hash = "sha256:837982ea24091d4c1700ddb2f63b7070e5baec508e43b01de013dc7eff974ff1"},
+    {file = "ruff-0.9.9-py3-none-win_arm64.whl", hash = "sha256:3ac78f127517209fe6d96ab00f3ba97cafe38718b23b1db3e96d8b2d39e37ddf"},
+    {file = "ruff-0.9.9.tar.gz", hash = "sha256:0062ed13f22173e85f8f7056f9a24016e692efeea8704d1a5e8011b8aa850933"},
 ]
 
 [[package]]
@@ -911,4 +930,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "~=3.9"
-content-hash = "ba1a1734f3be39ee4342946c7548061e71a248976ec400d6d78cfb458a43b0d3"
+content-hash = "3468993768c50a692587277c1411fe96401545429e75fd10528e9e81ead0c20d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,6 @@ ignore = [
     'PERF401', # Allow for loops that could be comprehensions. Sometimes this makes code easier to understand.
     'S104',    # Allow binding sockets to the wildcard interface. In our case, we apply socket options to those sockets so that they are restricted to specific interfaces and mcast IPs
     'PLR5501', # Stop collapsing my if statements!
-    'SIM105',  # Allow try-except-pass
 ]
 
 [tool.ruff.lint.flake8-quotes]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,4 +190,3 @@ stubPath = "stubs"
 # Reference here: https://pytest-asyncio.readthedocs.io/en/latest/reference/configuration.html
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
-asyncio_default_test_loop_scope = "function"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ name = "multicast_expert"
 # "~=3.9", so Poetry won't solve the versions since it cannot find a version of docsig that works for Python >=4
 requires-python = "~=3.9"
 
-version = "1.5.1"
+version = "1.6.0"
 description = "A library to take the fiddly parts out of multicast networking!"
 authors = [
     {name = "Jamie Smith", email = "jsmith@crackofdawn.onmicrosoft.com"}
@@ -51,6 +51,7 @@ build-backend = "poetry.core.masonry.api"
 pytest = ">=6.2"
 pytest-retry = ">=1.7.0"
 pytest-mock = ">=3.13.0"
+pytest-asyncio = ">=0.25.0"
 mypy = ">=1.8"
 ruff = '>=0.9'
 docsig = ">=0.67.0"
@@ -133,6 +134,7 @@ ignore = [
     'PERF401', # Allow for loops that could be comprehensions. Sometimes this makes code easier to understand.
     'S104',    # Allow binding sockets to the wildcard interface. In our case, we apply socket options to those sockets so that they are restricted to specific interfaces and mcast IPs
     'PLR5501', # Stop collapsing my if statements!
+    'SIM105',  # Allow try-except-pass
 ]
 
 [tool.ruff.lint.flake8-quotes]
@@ -182,3 +184,10 @@ mypy_path = "$MYPY_CONFIG_FILE_DIR/stubs"
 
 [tool.pyright]
 stubPath = "stubs"
+
+[tool.pytest.ini_options]
+# Configs for pytest-asyncio
+# Reference here: https://pytest-asyncio.readthedocs.io/en/latest/reference/configuration.html
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
+asyncio_default_test_loop_scope = "function"

--- a/tests/test_multicast_sockets.py
+++ b/tests/test_multicast_sockets.py
@@ -604,15 +604,15 @@ async def test_async_v4() -> None:
             # Lastly, let's test receiving a packet while in a recv() call.
             # We will use very large timeouts as who knows how long context switch delays are on GitLab CI runners...
             rx_socket.settimeout(1)
-            start_time = time.monotonic()
+            start_time = time.perf_counter()
             recv_task = asyncio.get_running_loop().create_task(rx_socket.recv())
             await asyncio.sleep(0.5)
 
-            send_time = time.monotonic()
+            send_time = time.perf_counter()
             external_iface_tx_socket.sendto(b"Test 4", (mcast_address_v4, port))
 
             assert await recv_task == b"Test 4"
-            recv_time = time.monotonic()
+            recv_time = time.perf_counter()
 
             # Check times. The recv async task should have returned pretty soon after we sent the packet.
             send_duration = send_time - start_time

--- a/tests/test_multicast_sockets.py
+++ b/tests/test_multicast_sockets.py
@@ -1,6 +1,7 @@
 import asyncio
 import platform
 import socket
+import sys
 import time
 import warnings
 from ipaddress import IPv4Address, IPv6Address
@@ -529,6 +530,7 @@ def test_external_loopback_disabled_v6(nonloopback_iface_ipv6: IfaceInfo) -> Non
         assert data == None
 
 
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="Async support requires python 3.11")
 async def test_async_v4() -> None:
     """
     Check that we can receive packets correctly using an Rx socket in asynchronous mode.

--- a/tests/test_multicast_sockets.py
+++ b/tests/test_multicast_sockets.py
@@ -564,7 +564,7 @@ async def test_async_v4() -> None:
         ) as rx_socket:
             # First, check that trying to receive without sending anything never completes and triggers a timeout
             with pytest.raises(asyncio.TimeoutError):
-                await asyncio.wait_for(asyncio.create_task(rx_socket.recv()), 0.5)
+                await asyncio.wait_for(rx_socket.recv(), 0.5)
 
             # Then check that setting a timeout does the same thing and raises a TimeoutError
             rx_socket.settimeout(0.1)
@@ -604,15 +604,15 @@ async def test_async_v4() -> None:
             # Lastly, let's test receiving a packet while in a recv() call.
             # We will use very large timeouts as who knows how long context switch delays are on GitLab CI runners...
             rx_socket.settimeout(1)
-            start_time = time.time()
+            start_time = time.monotonic()
             recv_task = asyncio.get_running_loop().create_task(rx_socket.recv())
             await asyncio.sleep(0.5)
 
-            send_time = time.time()
+            send_time = time.monotonic()
             external_iface_tx_socket.sendto(b"Test 4", (mcast_address_v4, port))
 
             assert await recv_task == b"Test 4"
-            recv_time = time.time()
+            recv_time = time.monotonic()
 
             # Check times. The recv async task should have returned pretty soon after we sent the packet.
             send_duration = send_time - start_time


### PR DESCRIPTION
This PR adds AsyncMcastRxSocket, which is a variant of McastRxSocket whose recv() and recvfrom() options are awaitable coroutines. This should make it way more convenient to use multicast from within asyncio event-based code!

Implementing this was actually a bit difficult, because Python asyncio is not very well set up to receive from multiple sockets at the same time. At first I tried [this SO post](https://stackoverflow.com/a/48250808/7083698)'s recommendation of using `EventLoop.add_reader()`, but soon found out the hard way that this is not available on Windows. Then I looked into a method that my colleague Colin H used in an internal tool. His solution works by creating a bunch of Tasks (one for each socket) that call 

```python
await asyncio.wait_for(asyncio.get_event_loop().sock_recv(sock, 4096), timeout)
```

and then calling `asyncio.gather()` on those tasks. This solution works, but with a big caveat: it requires all of the tasks to either complete or be canceled before gather() will return. So, if you call recv() with a timeout of 1 second, and one socket has a packet right away but the other socket has nothing, it will wait the full 1 second before returning.

The way to avoid this is to use `asyncio.wait(return_when=asyncio.FIRST_COMPLETED)`, which will return when any task has completed. That works, but then you're stuck with a bunch of other tasks that have not yet completed but still represent active recv() calls on the socket, and canceling those seems a bit sketchy (what if they completed and have packets to return?). 

So, I set up the class to create and start a Task for each socket in `__enter__`. Then, in recvfrom(), we find one task that has completed, grab the resultant packet, and then recreate the task to receive the next packet. This seems to work, and is actually quite a bit simpler than what I started with!

Note: The new additions currently require Python 3.11 or newer, and will not be available for import on older python versions. This is because `EventLoop.sock_recvfrom()` was added in 3.11. `sock_recv()` exists in 3.9 and 3.10, but using this method would prevent you from accessing the source address of the multicast, which is kinda limiting. So, I felt like a reasonable medium was to hide the new additions behind a Python version check.

Note 2: the only thing I think is a bit sketchy about this implementation is that what happens when it's closed. We try and cancel all the recvfrom tasks, but it isn't actually documented what happens when the result of `EventLoop.sock_recvfrom()` is canceled. What if it's received a packet? I feel like there's a good chance that packet can just be dropped. So, closing and reopening the AsyncMcastRxSocket could result in dropping packets that were queued in the OS. However, closing a socket already means you kinda don't care about what is being received on it, so I *think* this should be OK.